### PR TITLE
feat(Chatbox): adds space between end of messages and text input box

### DIFF
--- a/FrontEnd/src/ChatBox.js
+++ b/FrontEnd/src/ChatBox.js
@@ -27,12 +27,15 @@ const ChatBox = ({ room }) => {
                 message.ownedByCurrentPlayer ? "my-message" : "received-message"
               }`}
             >
-              {message.length > 10 ? `${message.body.slice(0, 13)} \n ${message.body.slice(14)}` : message.body}
+              {message.length > 10
+                ? `${message.body.slice(0, 13)} \n ${message.body.slice(14)}`
+                : message.body}
             </div>
           ))}
         </div>
       </div>
       <textarea
+        style={{ marginTop: "10px" }}
         value={newMessage}
         onChange={handleTypingMessage}
         placeholder="Write something..."


### PR DESCRIPTION
The last message in the chat box was right on top of the text input field. I added a little margin above it to space it more nicely.